### PR TITLE
Fix typo in network interface error message

### DIFF
--- a/internal/aghnet/net.go
+++ b/internal/aghnet/net.go
@@ -173,7 +173,7 @@ func GetValidNetInterfacesForWeb() (nifaces []*NetInterface, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("getting interfaces: %w", err)
 	} else if len(ifaces) == 0 {
-		return nil, errors.Error("no legible interfaces")
+		return nil, errors.Error("no eligible interfaces")
 	}
 
 	for i := range ifaces {


### PR DESCRIPTION
## Summary
- fix small typo in `aghnet` error text

## Testing
- `go vet ./...`
- `go test ./...` *(fails: reading from url: got status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_6843144b6214832381a4863c2dc82747