### PR TITLE
Add query log auto-refresh option

### DIFF
--- a/client/src/__locales/en.json
+++ b/client/src/__locales/en.json
@@ -280,6 +280,8 @@
     "query_log_retention_confirm": "Are you sure you want to change query log rotation? If you decrease the interval value, some data will be lost",
     "anonymize_client_ip": "Anonymize client IP",
     "anonymize_client_ip_desc": "Don't save the client's full IP address to logs or statistics",
+    "query_log_auto_update": "Auto update interval (seconds)",
+    "query_log_auto_update_desc": "Set to 0 to disable automatic refresh",
     "dns_config": "DNS server configuration",
     "dns_cache_config": "DNS cache configuration",
     "dns_cache_config_desc": "Here you can configure DNS cache",

--- a/client/src/actions/queryLogs.ts
+++ b/client/src/actions/queryLogs.ts
@@ -206,3 +206,5 @@ export const setLogsConfig = (config: any) => async (dispatch: any) => {
         dispatch(setLogsConfigFailure());
     }
 };
+
+export const setLogsRefreshInterval = createAction('SET_LOGS_REFRESH_INTERVAL');

--- a/client/src/components/Logs/index.tsx
+++ b/client/src/components/Logs/index.tsx
@@ -21,7 +21,13 @@ import { getClients } from '../../actions';
 import { getDnsConfig } from '../../actions/dnsConfig';
 import { getAccessList } from '../../actions/access';
 import { getAllBlockedServices } from '../../actions/services';
-import { getLogsConfig, resetFilteredLogs, setFilteredLogs, toggleDetailedLogs } from '../../actions/queryLogs';
+import {
+    getLogsConfig,
+    resetFilteredLogs,
+    setFilteredLogs,
+    toggleDetailedLogs,
+    refreshFilteredLogs,
+} from '../../actions/queryLogs';
 
 import InfiniteTable from './InfiniteTable';
 import './Logs.css';
@@ -89,6 +95,7 @@ const Logs = () => {
     const filter = useSelector((state: RootState) => state.queryLogs.filter, shallowEqual);
 
     const logs = useSelector((state: RootState) => state.queryLogs.logs, shallowEqual);
+    const refreshInterval = useSelector((state: RootState) => state.queryLogs.refreshInterval);
 
     const search = search_url_param || filter?.search || '';
     const response_status = response_status_url_param || filter?.response_status || '';
@@ -187,6 +194,21 @@ const Logs = () => {
             })();
         }
     }, [history.location.search]);
+
+    useEffect(() => {
+        let timer: any;
+        if (refreshInterval > 0) {
+            timer = setInterval(() => {
+                dispatch(refreshFilteredLogs());
+            }, refreshInterval);
+        }
+
+        return () => {
+            if (timer) {
+                clearInterval(timer);
+            }
+        };
+    }, [refreshInterval]);
 
     const renderPage = () => (
         <>

--- a/client/src/components/Settings/LogsConfig/Form.tsx
+++ b/client/src/components/Settings/LogsConfig/Form.tsx
@@ -30,6 +30,7 @@ export type FormValues = {
     interval: number;
     customInterval?: number | null;
     ignored: string;
+    refreshInterval: number;
 };
 
 type Props = {
@@ -57,6 +58,7 @@ export const Form = ({ initialValues, processing, processingReset, onSubmit, onR
             interval: initialValues.interval || DAY,
             customInterval: initialValues.customInterval || null,
             ignored: initialValues.ignored || '',
+            refreshInterval: initialValues.refreshInterval || 0,
         },
     });
 
@@ -92,6 +94,33 @@ export const Form = ({ initialValues, processing, processingReset, onSubmit, onR
                             data-testid="logs_enabled"
                             title={t('query_log_enable')}
                             disabled={processing}
+                        />
+                    )}
+                />
+            </div>
+
+            <label className="form__label form__label--with-desc">
+                <Trans>query_log_auto_update</Trans>
+            </label>
+
+            <div className="form__desc form__desc--top">
+                <Trans>query_log_auto_update_desc</Trans>
+            </div>
+
+            <div className="form__group form__group--settings">
+                <Controller
+                    name="refreshInterval"
+                    control={control}
+                    render={({ field }) => (
+                        <Input
+                            {...field}
+                            data-testid="logs_refresh_interval"
+                            disabled={processing}
+                            min={0}
+                            onChange={(e) => {
+                                const { value } = e.target;
+                                field.onChange(toNumber(value));
+                            }}
                         />
                     )}
                 />

--- a/client/src/components/Settings/LogsConfig/index.tsx
+++ b/client/src/components/Settings/LogsConfig/index.tsx
@@ -5,16 +5,19 @@ import Card from '../../ui/Card';
 
 import { Form, FormValues } from './Form';
 import { HOUR } from '../../../helpers/constants';
+import { LocalStorageHelper, LOCAL_STORAGE_KEYS } from '../../../helpers/localStorageHelper';
 
 interface LogsConfigProps {
     interval: number;
     customInterval?: number;
     enabled: boolean;
     anonymize_client_ip: boolean;
+    refreshInterval: number;
     processing: boolean;
     ignored: unknown[];
     processingClear: boolean;
     setLogsConfig: (...args: unknown[]) => unknown;
+    setLogsRefreshInterval: (...args: unknown[]) => unknown;
     clearLogs: (...args: unknown[]) => unknown;
     t: (...args: unknown[]) => string;
 }
@@ -22,7 +25,7 @@ interface LogsConfigProps {
 class LogsConfig extends Component<LogsConfigProps> {
     handleFormSubmit = (values: FormValues) => {
         const { t, interval: prevInterval } = this.props;
-        const { interval, customInterval, ...rest } = values;
+        const { interval, customInterval, refreshInterval, ...rest } = values;
 
         const newInterval = customInterval ? customInterval * HOUR : interval;
 
@@ -31,6 +34,10 @@ class LogsConfig extends Component<LogsConfigProps> {
             ignored: values.ignored ? values.ignored.split('\n') : [],
             interval: newInterval,
         };
+
+        const refreshMs = refreshInterval * 1000;
+        LocalStorageHelper.setItem(LOCAL_STORAGE_KEYS.QUERY_LOG_REFRESH_INTERVAL, refreshMs);
+        this.props.setLogsRefreshInterval(refreshMs);
 
         if (newInterval < prevInterval) {
             // eslint-disable-next-line no-alert
@@ -58,6 +65,7 @@ class LogsConfig extends Component<LogsConfigProps> {
             processing,
             processingClear,
             anonymize_client_ip,
+            refreshInterval,
             ignored,
             customInterval,
         } = this.props;
@@ -71,6 +79,7 @@ class LogsConfig extends Component<LogsConfigProps> {
                             interval,
                             customInterval,
                             anonymize_client_ip,
+                            refreshInterval: refreshInterval / 1000,
                             ignored: ignored?.join('\n'),
                         }}
                         processing={processing}

--- a/client/src/components/Settings/index.tsx
+++ b/client/src/components/Settings/index.tsx
@@ -51,6 +51,7 @@ interface SettingsProps {
     t: (...args: unknown[]) => string;
     getLogsConfig?: (...args: unknown[]) => unknown;
     setLogsConfig?: (...args: unknown[]) => unknown;
+    setLogsRefreshInterval?: (...args: unknown[]) => unknown;
     clearLogs?: (...args: unknown[]) => unknown;
     stats?: {
         processingGetConfig?: boolean;
@@ -70,6 +71,7 @@ interface SettingsProps {
         processingClear?: boolean;
         processingGetConfig?: boolean;
         ignored?: unknown[];
+        refreshInterval?: number;
     };
     filtering?: {
         interval?: number;
@@ -197,10 +199,12 @@ class Settings extends Component<SettingsProps> {
                                     ignored={queryLogs.ignored}
                                     interval={queryLogs.interval}
                                     customInterval={queryLogs.customInterval}
+                                    refreshInterval={queryLogs.refreshInterval}
                                     anonymize_client_ip={queryLogs.anonymize_client_ip}
                                     processing={queryLogs.processingSetConfig}
                                     processingClear={queryLogs.processingClear}
                                     setLogsConfig={setLogsConfig}
+                                    setLogsRefreshInterval={this.props.setLogsRefreshInterval}
                                     clearLogs={clearLogs}
                                 />
                             </div>

--- a/client/src/containers/Settings.ts
+++ b/client/src/containers/Settings.ts
@@ -3,7 +3,12 @@ import { connect } from 'react-redux';
 import { initSettings, toggleSetting } from '../actions';
 import { getBlockedServices, updateBlockedServices } from '../actions/services';
 import { getStatsConfig, setStatsConfig, resetStats } from '../actions/stats';
-import { clearLogs, getLogsConfig, setLogsConfig } from '../actions/queryLogs';
+import {
+    clearLogs,
+    getLogsConfig,
+    setLogsConfig,
+    setLogsRefreshInterval,
+} from '../actions/queryLogs';
 import { getFilteringStatus, setFiltersConfig } from '../actions/filtering';
 
 import Settings from '../components/Settings';
@@ -31,6 +36,7 @@ const mapDispatchToProps = {
     clearLogs,
     getLogsConfig,
     setLogsConfig,
+    setLogsRefreshInterval,
     getFilteringStatus,
     setFiltersConfig,
 };

--- a/client/src/helpers/constants.ts
+++ b/client/src/helpers/constants.ts
@@ -217,6 +217,8 @@ export const DEFAULT_LANGUAGE = 'en';
 
 export const QUERY_LOGS_PAGE_LIMIT = 20;
 
+export const LOGS_REFRESH_INTERVALS_SECONDS = [0, 5, 10, 30];
+
 export const LEASES_TABLE_DEFAULT_PAGE_SIZE = 20;
 
 export const FILTERED_STATUS = {

--- a/client/src/helpers/localStorageHelper.ts
+++ b/client/src/helpers/localStorageHelper.ts
@@ -5,6 +5,7 @@ export const LOCAL_STORAGE_KEYS = {
     CLIENTS_PAGE_SIZE: 'clients_page_size',
     REWRITES_PAGE_SIZE: 'rewrites_page_size',
     AUTO_CLIENTS_PAGE_SIZE: 'auto_clients_page_size',
+    QUERY_LOG_REFRESH_INTERVAL: 'query_log_refresh_interval',
 };
 
 export const LocalStorageHelper = {

--- a/client/src/initialState.ts
+++ b/client/src/initialState.ts
@@ -6,6 +6,7 @@ import {
     STANDARD_WEB_PORT,
     TIME_UNITS,
 } from './helpers/constants';
+import { LocalStorageHelper, LOCAL_STORAGE_KEYS } from './helpers/localStorageHelper';
 import { DEFAULT_BLOCKING_IPV4, DEFAULT_BLOCKING_IPV6 } from './reducers/dnsConfig';
 import { Filter } from './helpers/helpers';
 
@@ -365,6 +366,7 @@ export type QueryLogsData = {
     isDetailed: boolean;
     isEntireLog: boolean;
     customInterval: any;
+    refreshInterval: number;
 };
 
 export type ServicesData = {
@@ -567,6 +569,7 @@ export const initialState: RootState = {
         isDetailed: true,
         isEntireLog: false,
         customInterval: null,
+        refreshInterval: LocalStorageHelper.getItem(LOCAL_STORAGE_KEYS.QUERY_LOG_REFRESH_INTERVAL) || 0,
     },
     rewrites: {
         processing: true,

--- a/client/src/reducers/queryLogs.ts
+++ b/client/src/reducers/queryLogs.ts
@@ -2,6 +2,7 @@ import { handleActions } from 'redux-actions';
 
 import * as actions from '../actions/queryLogs';
 import { DEFAULT_LOGS_FILTER, DAY, QUERY_LOG_INTERVALS_DAYS, HOUR } from '../helpers/constants';
+import { LocalStorageHelper, LOCAL_STORAGE_KEYS } from '../helpers/localStorageHelper';
 
 const queryLogs = handleActions(
     {
@@ -104,6 +105,11 @@ const queryLogs = handleActions(
             processingSetConfig: false,
         }),
 
+        [actions.setLogsRefreshInterval.toString()]: (state, { payload }: any) => ({
+            ...state,
+            refreshInterval: payload,
+        }),
+
         [actions.getAdditionalLogsRequest.toString()]: (state: any) => ({
             ...state,
             processingAdditionalLogs: true,
@@ -137,6 +143,7 @@ const queryLogs = handleActions(
         isDetailed: true,
         isEntireLog: false,
         customInterval: null,
+        refreshInterval: LocalStorageHelper.getItem(LOCAL_STORAGE_KEYS.QUERY_LOG_REFRESH_INTERVAL) || 0,
     },
 );
 


### PR DESCRIPTION
## Summary
- support auto-refresh duration for query logs
- persist duration in local storage
- expose refresh interval setting in general settings UI
- periodically refresh logs based on the configured interval

## Testing
- `make js-test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431d843ea883239a0a8b49716d1f49